### PR TITLE
Create a GH Action Verification build

### DIFF
--- a/.github/workflows/tck.yml
+++ b/.github/workflows/tck.yml
@@ -1,0 +1,34 @@
+name: Run TCK
+
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
+
+jobs:
+  build:
+    strategy:
+      fail-fast: false
+      matrix:
+       config: 
+        - { name: 'JDBC', file: 'org.osgi.compatibility.jdbc/pom.xml' }
+        - { name: 'JAX RS', file: 'org.osgi.compatibility.jaxrs/pom.xml' }
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v3
+    - name: Set up JDK 11
+      uses: actions/setup-java@v3
+      with:
+        java-version: '11'
+        distribution: 'temurin'
+        cache: maven
+    - name: ${{ matrix.config.name }} TCK
+      run: mvn -B clean verify --file ${{ matrix.config.file }} -Dbnd.testing.failure.ignore=true
+    - name: Upload Test Results
+      uses: actions/upload-artifact@v3
+      with:
+        name: test-results-${{ matrix.config.name }}
+        if-no-files-found: error
+        path: '**/target/test-reports/**/*.xml'

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -1,0 +1,39 @@
+name: Publish Unit Test Results
+
+on:
+  workflow_run:
+    workflows: ["Run TCK"]
+    types:
+      - completed
+
+jobs:
+  unit-test-results:
+    name: Unit Test Results
+    runs-on: ubuntu-latest
+    if: github.event.workflow_run.conclusion == 'success'
+
+    steps:
+      - name: Download and Extract Artifacts
+        env:
+          GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
+        run: |
+           mkdir -p artifacts && cd artifacts
+
+           artifacts_url=${{ github.event.workflow_run.artifacts_url }}
+
+           gh api "$artifacts_url" -q '.artifacts[] | [.name, .archive_download_url] | @tsv' | while read artifact
+           do
+             IFS=$'\t' read name url <<< "$artifact"
+             gh api $url > "$name.zip"
+             unzip -d "$name" "$name.zip"
+           done
+
+      - name: Publish Unit Test Results
+        uses: EnricoMi/publish-unit-test-result-action@v1
+        with:
+          commit: ${{ github.event.workflow_run.head_sha }}
+          files: "artifacts/**/*.xml"
+
+
+
+

--- a/org.osgi.compatibility.jdbc/org.osgi.compatibility.jdbc.osgi.impl/pom.xml
+++ b/org.osgi.compatibility.jdbc/org.osgi.compatibility.jdbc.osgi.impl/pom.xml
@@ -13,7 +13,7 @@
 		<dependency>
 			<groupId>org.osgi</groupId>
 			<artifactId>org.osgi.impl.service.jdbc</artifactId>
-			<version>9.0.0-SNAPSHOT</version>
+			<version>8.0.0-SNAPSHOT</version>
 		</dependency>
 	</dependencies>
 

--- a/org.osgi.compatibility.jdbc/pom.xml
+++ b/org.osgi.compatibility.jdbc/pom.xml
@@ -10,7 +10,7 @@
 	<packaging>pom</packaging>
 	<modules>
 		<module>org.osgi.compatibility.jdbc.mssqlserver</module>
-		<module>org.osgi.compatibility.jdbc.osgi.impl</module>
+<!--		<module>org.osgi.compatibility.jdbc.osgi.impl</module>-->
 	</modules>
 
 	<dependencies>
@@ -19,6 +19,11 @@
 			<artifactId>org.osgi.test.cases.jdbc</artifactId>
 			<version>8.0.0-SNAPSHOT</version>
 			<scope>runtime</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.osgi</groupId>
+			<artifactId>org.osgi.service.jdbc</artifactId>
+			<version>1.0.1</version>
 		</dependency>
 	</dependencies>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -19,9 +19,22 @@
 			</snapshots>
 		</repository>
 	</repositories>
+	<pluginRepositories>
+		<pluginRepository>
+			<id>bnd-snapshots</id>
+			<url>https://bndtools.jfrog.io/bndtools/libs-snapshot/</url>
+			<layout>default</layout>
+			<releases>
+				<enabled>false</enabled>
+			</releases>
+			<snapshots>
+				<enabled>true</enabled>
+			</snapshots>
+		</pluginRepository>
+	</pluginRepositories>
 	<properties>
 		<revision>0.0.1-SNAPSHOT</revision>
-		<bnd.version>6.2.0</bnd.version>
+		<bnd.version>6.4.0-SNAPSHOT</bnd.version>
 		<felix.framework.version>7.0.3</felix.framework.version>
 		<org.eclipse.osgi.version>3.17.200</org.eclipse.osgi.version>
 	</properties>
@@ -39,11 +52,6 @@
 				<version>1.2.0</version>
 			</dependency>
 			<dependency>
-				<groupId>org.osgi</groupId>
-				<artifactId>org.osgi.util.promise</artifactId>
-				<version>1.2.0</version>
-			</dependency>
-						<dependency>
 				<groupId>org.osgi</groupId>
 				<artifactId>org.osgi.util.promise</artifactId>
 				<version>1.2.0</version>


### PR DESCRIPTION
This is a first attempt to have an automatic github verification when accepting contributions.

Currently it fails because some snapshot dependencies are not found, possible options include:

1. ask for a repository where the OSGi snapshots are deployed
2. build the necessary dependencies as part of the build